### PR TITLE
Fix `no_std` compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -19,7 +19,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
 ]
 
 [[package]]
@@ -42,9 +41,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -66,9 +65,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "serde"
@@ -92,9 +91,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
  "memchr",
@@ -107,6 +106,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
@@ -123,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -134,6 +136,6 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,13 @@ name = "disarm64_defn"
 path = "src/lib.rs"
 
 [dependencies]
-bitflags = { version = "2.4", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-strum = "0.26"
-strum_macros = "0.26"
+bitflags = { version = "2.8.0", features = ["serde"] }
+serde = { version = "1.0.217", features = ["derive"], default-features = false }
+strum = { version = "0.26.3", features = ["derive"] , default-features = false }
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.138"
 
 [features]
 default = ["std"]
-std = []
+std = ["strum/std", "serde/std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,10 @@ extern crate std;
 use bitflags::bitflags;
 use serde::Deserialize;
 use serde::Serialize;
-use strum_macros::EnumIter;
+use strum::{EnumIter, IntoStaticStr};
 
 #[cfg(feature = "std")]
 use strum::IntoEnumIterator;
-use strum_macros::IntoStaticStr;
 
 /// The AArch64 instruction classes.
 #[allow(non_camel_case_types)]


### PR DESCRIPTION
Disabling the `std` feature still resulted in broken builds on `no_std` platforms due to the `serde` and `strum` `std` features still being enabled. This PR fixes that.